### PR TITLE
Get git commit hash even if the repo only points to a bare repo.

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,16 @@ var eejs = require('ep_etherpad-lite/node/eejs/')
 
 //try to get the git version
 var rootPath = path.resolve(__dirname, '../..')
-var ref = fs.readFile(rootPath + "/.git/HEAD", "utf-8", function(err, branch) {
+if (fs.lstatSync(rootPath + '/.git').isFile()) {
+  rootPath = fs.readFileSync(rootPath + '/.git', "utf8");
+  rootPath = rootPath.split(' ').pop().trim();
+} else {
+  rootPath += '/.git';
+}
+var ref = fs.readFile(rootPath + "/HEAD", "utf-8", function(err, branch) {
   if(err) return console.error(err);
   branchPath = branch.substring(5, branch.indexOf("\n"))
-  fs.readFile(rootPath+"/.git/"+branchPath, "utf-8", function(err, head) {
+  fs.readFile(rootPath+"/"+branchPath, "utf-8", function(err, head) {
     if(err) return console.error(err);
     gitref = head.substring(0, 6)
     console.log("ep_infopanel: Ep-lite git revision: "+gitref)


### PR DESCRIPTION
- Used by https://github.com/debops/ansible-etherpad
- Related to: https://github.com/ether/etherpad-lite/pull/2798
